### PR TITLE
Add GitHub Pages deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,32 @@ This project is built with:
 
 Simply open [Lovable](https://lovable.dev/projects/c4e532e7-f2b8-4551-9f19-e5953012040e) and click on Share -> Publish.
 
+## Deploying to GitHub Pages
+
+If you prefer to host the static build on GitHub Pages, follow these steps:
+
+1. Install the **gh-pages** package:
+
+   ```sh
+   npm install -D gh-pages
+   ```
+
+2. Build the project:
+
+   ```sh
+   npm run build
+   ```
+
+3. Deploy the contents of the `dist` folder:
+
+   ```sh
+   npm run deploy
+   ```
+
+The `vite.config.ts` file has the `base` option set to `/resume-boost-landing-page/` so assets load correctly on GitHub Pages.
+
+After running `npm run deploy`, configure the repository to serve the **gh-pages** branch in the GitHub Pages settings.
+
 ## Can I connect a custom domain to my Lovable project?
 
 Yes, you can!

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "deploy": "gh-pages -d dist"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",
@@ -62,6 +63,7 @@
     "zod": "^3.23.8"
   },
   "devDependencies": {
+    "gh-pages": "^6.0.0",
     "@eslint/js": "^9.9.0",
     "@tailwindcss/typography": "^0.5.15",
     "@types/node": "^22.5.5",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,7 @@ import { componentTagger } from "lovable-tagger";
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => ({
+  base: mode === 'production' ? '/resume-boost-landing-page/' : '/',
   server: {
     host: "::",
     port: 8080,


### PR DESCRIPTION
## Summary
- configure Vite `base` for GitHub Pages
- add `deploy` script with `gh-pages`
- document how to deploy to GitHub Pages in README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684ef5acb4048328b9bd5862c039b66c