### PR TITLE
Fix before/after images path

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,7 +1,10 @@
 import { useState } from "react";
 import { ChevronDown, ChevronUp, MessageCircle, CheckCircle2, FileText, FileSearch2, Rocket, BookText, Users2, Star } from "lucide-react";
-const antesImg = `${import.meta.env.BASE_URL}lovable-uploads/a42d453d-859a-4160-a9a7-7b70b0cfcc67.png`;
-const depoisImg = `${import.meta.env.BASE_URL}lovable-uploads/c8d0b988-c458-4bc1-9a9f-593ad8209b49.png`;
+
+// Resolve image URLs relative to this file so Vite includes them in the build
+// and generates paths that work with the GitHub Pages base URL.
+const antesImg = new URL("../../public/lovable-uploads/a42d453d-859a-4160-a9a7-7b70b0cfcc67.png", import.meta.url).href;
+const depoisImg = new URL("../../public/lovable-uploads/c8d0b988-c458-4bc1-9a9f-593ad8209b49.png", import.meta.url).href;
 
 // Depoimentos mockados:
 const testimonials = [


### PR DESCRIPTION
## Summary
- use `new URL()` to ensure the before/after images are bundled so GitHub Pages can load them

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684f031e9f408328aba49d7eccff4f52